### PR TITLE
Implement transform for stage 1 (Batman syntax removal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 ## Transforms
 
 <!--TRANSFORMS_START-->
+* [stage-1-batman-begone](transforms/stage-1-batman-begone/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/__tests__/common/naming.test.js
+++ b/__tests__/common/naming.test.js
@@ -1,0 +1,88 @@
+const naming = require('../../common/naming');
+
+describe('naming', () => {
+  describe('getWords', () => {
+    it('can get words from camelCased names', () => {
+      expect(naming.getWords('camelCasedName')).toEqual(['camel', 'cased', 'name']);
+    });
+
+    it('can get words from dot.cased names', () => {
+      expect(naming.getWords('dot.cased.name')).toEqual(['dot', 'cased', 'name']);
+    });
+
+    it('can get words from kebab-case names', () => {
+      expect(naming.getWords('kebab-cased-name')).toEqual(['kebab', 'cased', 'name']);
+    });
+
+    it('can get words from PascalCased names', () => {
+      expect(naming.getWords('PascalCasedName')).toEqual(['pascal', 'cased', 'name']);
+    });
+
+    it('can get words from snake_cased names', () => {
+      expect(naming.getWords('snake_cased_name')).toEqual(['snake', 'cased', 'name']);
+    });
+
+    it('can get words from a mixed case name', () => {
+      expect(naming.getWords('Very-long_mixed.caseName')).toEqual([
+        'very',
+        'long',
+        'mixed',
+        'case',
+        'name',
+      ]);
+    });
+
+    it('attaches numbers to the previous word', () => {
+      expect(naming.getWords('this123THAT456Other789a1b2c3d')).toEqual([
+        'this123',
+        'that456',
+        'other789',
+        'a1',
+        'b2',
+        'c3',
+        'd',
+      ]);
+    });
+
+    it('correctly handles sequences of delimiters in a name', () => {
+      expect(naming.getWords('__foo..bar--baz__quux..')).toEqual(['foo', 'bar', 'baz', 'quux']);
+    });
+
+    it('correctly handles sequences of capital letters at the  beginning of a name', () => {
+      expect(naming.getWords('HTTPRequest')).toEqual(['http', 'request']);
+    });
+
+    it('correctly handles sequences of capital letters in the middle of a name', () => {
+      expect(naming.getWords('xmlHTTPRequest')).toEqual(['xml', 'http', 'request']);
+    });
+
+    it('correctly handles sequences of capital letters at the end of a name', () => {
+      expect(naming.getWords('xmlHTTP')).toEqual(['xml', 'http']);
+    });
+
+    it('correctly handles single-letter words', () => {
+      expect(naming.getWords('A.b-c_dE')).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+  });
+
+  // All remaining tests use the same input, which is also one of the inputs explicitly checked for
+  // getName above, so that only output style is tested below and input style is tested above.
+
+  describe('toCamelCase', () => {
+    it('produces camelCased output', () => {
+      expect(naming.toCamelCase('Very-long_mixed.caseName')).toEqual('veryLongMixedCaseName');
+    });
+  });
+
+  describe('toKebabCase', () => {
+    it('produces kebab-cased output', () => {
+      expect(naming.toKebabCase('Very-long_mixed.caseName')).toEqual('very-long-mixed-case-name');
+    });
+  });
+
+  describe('toPascalCase', () => {
+    it('produces PascalCased output', () => {
+      expect(naming.toPascalCase('Very-long_mixed.caseName')).toEqual('VeryLongMixedCaseName');
+    });
+  });
+});

--- a/common/naming.js
+++ b/common/naming.js
@@ -1,0 +1,54 @@
+module.exports = {
+  /** Get the lowercase words delimited in a name.
+   *
+   * Words are split on non-alphanumerics, before a capital letter which doesn't follow another
+   * capital letter iff it is also followed by a lowercase letter, and after numbers which have a
+   * non-number after them.
+   *
+   * @param {string} name The name to split.
+   * @returns {string[]} An array of lowercase words.
+   */
+  getWords(name) {
+    return name
+      .replace(/([0-9a-z])([A-Z])/g, '$1\0$2') // split before upper after non-upper
+      .replace(/([A-Z])([A-Z][a-z])/g, '$1\0$2') // split before (upper then lower) after upper
+      .replace(/([0-9])([^0-9])/g, '$1\0$2') // split after number followed by non-number
+      .replace(/[^0-9A-Za-z]+/g, '\0') // split on non-alphanumerics
+      .split('\0')
+      .filter(Boolean) // remove empty "words" from beginning/end
+      .map((word) => word.toLowerCase());
+  },
+
+  /** Convert a name in any casing style to camelCase.
+   *
+   * @param {string} name The name to convert.
+   * @returns {string} The name in camelCase.
+   */
+  toCamelCase(name) {
+    return module.exports
+      .getWords(name)
+      .map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+      .join('');
+  },
+
+  /** Convert a name in any casing style to kebab-case.
+   *
+   * @param {string} name The name to convert.
+   * @returns {string} The name in kebab-case.
+   */
+  toKebabCase(name) {
+    return module.exports.getWords(name).join('-');
+  },
+
+  /** Convert a name in any casing style to PascalCase.
+   *
+   * @param {string} name The name to convert.
+   * @returns {string} The name in PascalCase.
+   */
+  toPascalCase(name) {
+    return module.exports
+      .getWords(name)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('');
+  },
+};

--- a/transforms/stage-1-batman-begone/README.md
+++ b/transforms/stage-1-batman-begone/README.md
@@ -1,0 +1,73 @@
+# stage-1-batman-begone
+
+It's this summer's blockbuster sequel to [ember-holy-futuristic-template-namespacing-batman](https://github.com/rwjblue/ember-holy-futuristic-template-namespacing-batman) — batman-begone!
+
+The first stage in migrating your codebase to first-class templates is to migrate any usages of "batman syntax" (e.g. `<div {{some-addon$some-modifier args}}>content</div>`) to equivalent invokations using core Ember features (e.g. `<div {{modifier "some-addon@some-modifier" args}}>content</div>`). This puts all scoped references on equal footing for later codemods and allows the removal of ember-holy-futuristic-template-namespacing-batman from your package.
+
+Note that batman-begone will bulk up templates which were using Batman syntax by a bit ([see the examples below](#input--output)). But don't worry! This is only temporary, and later transforms in the codemod will remove all that ugly boilerplate amd leave your code beautiful again.
+
+## Usage
+
+```
+npx ember-first-class-component-templates-migrator stage-1-batman-begone path/of/files/ or/some**/*glob.hbs
+
+# or
+
+yarn global add ember-first-class-component-templates-migrator
+ember-first-class-component-templates-migrator stage-1-batman-begone path/of/files/ or/some**/*glob.hbs
+```
+
+## Local Usage
+
+```
+node ./bin/cli.js stage-1-batman-begone path/of/files/ or/some**/*glob.hbs
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [basic](#basic)
+<!--FIXTURES_TOC_END-->
+
+## <!--FIXTURES_CONTENT_START-->
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.hbs](transforms/stage-1-batman-begone/__testfixtures__/basic.input.hbs)</small>):
+```hbs
+<SomeAddon$SomeComponent attribute=value />
+
+{{some-addon$some-curly "foo" (bar "baz")}}
+
+{{#if (some-addon$some-helper args)}}
+  content1
+{{/if}}
+
+<div {{some-addon$some-modifier args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>
+
+```
+
+**Output** (<small>[basic.output.hbs](transforms/stage-1-batman-begone/__testfixtures__/basic.output.hbs)</small>):
+```hbs
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" (bar "baz"))) (component "some-addon@some-curly" "foo" (bar "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>
+
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/stage-1-batman-begone/__testfixtures__/basic.input.hbs
+++ b/transforms/stage-1-batman-begone/__testfixtures__/basic.input.hbs
@@ -1,0 +1,14 @@
+<SomeAddon$SomeComponent attribute=value />
+
+{{some-addon$some-curly "foo" (bar "baz")}}
+
+{{#if (some-addon$some-helper args)}}
+  content1
+{{/if}}
+
+<div {{some-addon$some-modifier args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>

--- a/transforms/stage-1-batman-begone/__testfixtures__/basic.output.hbs
+++ b/transforms/stage-1-batman-begone/__testfixtures__/basic.output.hbs
@@ -1,0 +1,14 @@
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" (bar "baz"))) (component "some-addon@some-curly" "foo" (bar "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>

--- a/transforms/stage-1-batman-begone/index.js
+++ b/transforms/stage-1-batman-begone/index.js
@@ -1,0 +1,69 @@
+const { toKebabCase } = require('../../common/naming');
+
+module.exports = function batmanBegone({ source /*, path*/ }, { parse, visit }) {
+  const ast = parse(source);
+
+  return visit(ast, (env) => {
+    let { builders: b } = env.syntax;
+
+    return {
+      ElementModifierStatement(node) {
+        if (!node.path.parts[0].includes('$')) {
+          return;
+        }
+
+        const [addon, modifier] = node.path.parts[0].split('$');
+
+        node.path = b.path('modifier');
+        node.params.unshift(b.string(`${addon}@${modifier}`));
+      },
+
+      ElementNode(node) {
+        if (!node.tag.includes('$')) {
+          return;
+        }
+
+        const [addon, component] = node.tag.split('$');
+
+        node.tag = component;
+
+        return b.block(
+          'let',
+          [b.sexpr('component', [b.string(`${toKebabCase(addon)}@${toKebabCase(component)}`)])],
+          b.hash(),
+          b.blockItself([node], [component])
+        );
+      },
+
+      MustacheStatement(node) {
+        if (!node.path.parts[0].includes('$')) {
+          return;
+        }
+
+        const [addon, curly] = node.path.parts[0].split('$');
+
+        return b.mustache('if', [
+          b.sexpr('isHelper', [
+            b.string(`${addon}@${curly}`),
+            b.sexpr('helper', [b.string(`${addon}@${curly}`), ...node.params]),
+          ]),
+
+          b.sexpr('component', [b.string(`${addon}@${curly}`), ...node.params]),
+        ]);
+      },
+
+      SubExpression(node) {
+        if (!node.path.parts[0].includes('$')) {
+          return;
+        }
+
+        const [addon, helper] = node.path.parts[0].split('$');
+
+        node.path = b.path('helper');
+        node.params.unshift(b.string(`${addon}@${helper}`));
+      },
+    };
+  });
+};
+
+module.exports.type = 'hbs';

--- a/transforms/stage-1-batman-begone/test.js
+++ b/transforms/stage-1-batman-begone/test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  name: 'stage-1-batman-begone',
+});


### PR DESCRIPTION
## Summary

This is a simple transform for HBS templates to remove Batman syntax. Take a look at `basic.input.hbs` and `basic.output.hbs` for examples of the changes made.

It also introduces a `naming` module, which will be shared between transforms.

## Testing

The new transform relies entirely on the testing tools provided by codemod-cli, so `basic.input.hbs` and `basic.output.hbs` serve as test snapshots. `naming` has traditional unit tests which use Jest directly.