### PR TITLE
Bump node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
     - name: install dependencies
       run: yarn install --frozen-lockfile
     - name: linting
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        node: ['12', '14', '16']
 
     steps:
     - uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '16.x'
     - name: install dependencies
       run: yarn install --no-lockfile
     - name: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "^2.6.2"
       },
       "engines": {
-        "node": "10.* || 12.* || >= 14"
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "^2.6.2"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
Dependencies are complaining about being run on Node v10, which is EOL anyway, and it's causing CI to fail for #2.