### PR TITLE
Implement transform for stage 4 (runtime resolution for unknown names)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
   },
 
   plugins: ['prettier', 'node'],

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 
 <!--TRANSFORMS_START-->
 * [stage-1-batman-begone](transforms/stage-1-batman-begone/README.md)
+* [stage-4-new-years](transforms/stage-4-new-years/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,0 +1,1 @@
+module.exports = { nameMapFile: 'names-from-templates.json' };

--- a/common/filesystem.js
+++ b/common/filesystem.js
@@ -1,0 +1,27 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = {
+  getPackageRoot(startPath) {
+    return module.exports.searchAncestors(startPath, 'package.json');
+  },
+
+  searchAncestors(startPath, targetPath) {
+    let current = path.resolve(startPath);
+
+    while (!fs.existsSync(path.join(current, targetPath))) {
+      const parent = path.dirname(current);
+
+      if (parent === current) {
+        // This indicates we hit a root (e.g. `/` or `C:\`), which means we've run
+        // out of places to look.
+
+        throw new Error(`Could not find '${targetPath}' in the ancestors of '${startPath}'.`);
+      }
+
+      current = parent;
+    }
+
+    return current;
+  },
+};

--- a/common/json.js
+++ b/common/json.js
@@ -1,0 +1,38 @@
+const fs = require('node:fs');
+
+module.exports = {
+  readJsonFile(jsonPath) {
+    try {
+      return JSON.parse(fs.readFileSync(jsonPath), 'utf8');
+    } catch (error) {
+      // Errors thrown by `readFileSync` are system errors, which aren't a
+      // subclass of `Error`, but can be identified by the presence of a
+      // `syscall` property.
+      if ('syscall' in error) {
+        throw new Error(`Could not read '${jsonPath}': "${error}"`);
+      }
+
+      // The JSON parser throws instances of `SyntaxError`.
+      if (error instanceof SyntaxError) {
+        throw new Error(`'${jsonPath}' does not appear to be valid JSON: "${error}"`);
+      }
+
+      throw error;
+    }
+  },
+
+  writeJsonFile(jsonPath, data) {
+    try {
+      fs.writeFileSync(jsonPath, JSON.stringify(data));
+    } catch (error) {
+      // Errors thrown by `readFileSync` are system errors, which aren't a
+      // subclass of `Error`, but can be identified by the presence of a
+      // `syscall` property.
+      if ('syscall' in error) {
+        throw new Error(`Could not read '${jsonPath}': "${error}"`);
+      }
+
+      throw error;
+    }
+  },
+};

--- a/transforms/stage-4-new-years/README.md
+++ b/transforms/stage-4-new-years/README.md
@@ -1,0 +1,84 @@
+# stage-4-new-years
+
+Have you made your resolutions? Well, your templates still need to! Now that the codemod has located the sources for as many of the names in your templates as it can, it's time to ask Ember to resolve (at runtime) any names that still don't have a source associated with them.
+
+Basically, the following transforms are made for any names which the codemod recognizes as still unknown:
+
+- unknown components: `<Foo />` → `{{#let (component "foo") as |Foo|}}<Foo />{{/let}}`
+- unknown helpers: `(foo "bar")` → `((resolve "foo" type="helper") "bar")`
+- unknown modifers: `<span {{foo}}>bar</span>` → `<span {{(resolve "foo" type="modifier")}}>bar</span>`
+- unknown "curlies" (can be either components or helpers): `{{foo}}` →
+
+  ```hbs
+  {{#let
+    (resolve "foo" type="helper")
+    (resolve "foo" type="component")
+    as |fooHelper fooComponent|
+  }}{{if fooHelper fooHelper fooComponent}}{{/let}}
+  ```
+
+## Usage
+
+```
+npx ember-first-class-component-templates-migrator stage-4-new-years path/of/files/ or/some**/*glob.hbs
+
+# or
+
+yarn global add ember-first-class-component-templates-migrator
+ember-first-class-component-templates-migrator stage-4-new-years path/of/files/ or/some**/*glob.hbs
+```
+
+## Local Usage
+
+```
+node ./bin/cli.js stage-4-new-years path/of/files/ or/some**/*glob.hbs
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [basic](#basic)
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.hbs](transforms/stage-4-new-years/__testfixtures__/basic.input.hbs)</small>):
+```hbs
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" (bar "baz"))) (component "some-addon@some-curly" "foo" (bar "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>
+
+```
+
+**Output** (<small>[basic.output.hbs](transforms/stage-4-new-years/__testfixtures__/basic.output.hbs)</small>):
+```hbs
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" ((resolve "bar" type="helper") "baz"))) (component "some-addon@some-curly" "foo" ((resolve "bar" type="helper") "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+{{#let (component "foo") as |Foo|}}<Foo />{{/let}}
+{{#if ((resolve "baz" type="helper") whatever)}}content3{{/if}}
+{{#let (resolve "bar" type="helper") (resolve "bar" type="component") as |barHelper barComponent|}}{{if barHelper barHelper barComponent}}{{/let}}
+<div {{(resolve "wat" type="modifier")}}></div>
+
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/stage-4-new-years/__testfixtures__/basic.input.hbs
+++ b/transforms/stage-4-new-years/__testfixtures__/basic.input.hbs
@@ -1,0 +1,14 @@
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" (bar "baz"))) (component "some-addon@some-curly" "foo" (bar "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+<Foo />
+{{#if (baz whatever)}}content3{{/if}}
+{{bar}}
+<div {{wat}}></div>

--- a/transforms/stage-4-new-years/__testfixtures__/basic.output.hbs
+++ b/transforms/stage-4-new-years/__testfixtures__/basic.output.hbs
@@ -1,0 +1,14 @@
+{{#let (component "some-addon@some-component") as |SomeComponent|}}<SomeComponent attribute=value />{{/let}}
+
+{{if (isHelper "some-addon@some-curly" (helper "some-addon@some-curly" "foo" ((resolve "bar" type="helper") "baz"))) (component "some-addon@some-curly" "foo" ((resolve "bar" type="helper") "baz"))}}
+
+{{#if (helper "some-addon@some-helper" args)}}
+  content1
+{{/if}}
+
+<div {{modifier "some-addon@some-modifier" args}}>content2</div>
+
+{{#let (component "foo") as |Foo|}}<Foo />{{/let}}
+{{#if ((resolve "baz" type="helper") whatever)}}content3{{/if}}
+{{#let (resolve "bar" type="helper") (resolve "bar" type="component") as |barHelper barComponent|}}{{if barHelper barHelper barComponent}}{{/let}}
+<div {{(resolve "wat" type="modifier")}}></div>

--- a/transforms/stage-4-new-years/__testfixtures__/names-from-templates.json
+++ b/transforms/stage-4-new-years/__testfixtures__/names-from-templates.json
@@ -1,0 +1,22 @@
+{
+  "basic.hbs": {
+    "known": {
+      "some-component": {}
+    },
+    "unknown": {
+      "ambiguousCurlies": [
+        "bar"
+      ],
+      "angleComponents": [
+        "Foo"
+      ],
+      "helpers": [
+        "bar",
+        "baz"
+      ],
+      "modifiers": [
+        "wat"
+      ]
+    }
+  }
+}

--- a/transforms/stage-4-new-years/__testfixtures__/package.json
+++ b/transforms/stage-4-new-years/__testfixtures__/package.json
@@ -1,0 +1,3 @@
+{
+  "description": "This file exists so that the fixtures directory is treated as a package and used to locate the names map."
+}

--- a/transforms/stage-4-new-years/index.js
+++ b/transforms/stage-4-new-years/index.js
@@ -1,0 +1,176 @@
+const path = require('node:path');
+
+const { nameMapFile } = require('../../common/constants');
+const { getPackageRoot } = require('../../common/filesystem');
+const { readJsonFile } = require('../../common/json');
+const { toKebabCase } = require('../../common/naming');
+
+function buildResolver(b, name, type) {
+  return b.sexpr('resolve', [b.string(name)], b.hash([b.pair('type', b.string(type))]));
+}
+
+function getUnknownNames(namesByAddon) {
+  const unknownNames = Object.create(null);
+
+  for (const [type, names] of Object.entries(namesByAddon.unknown)) {
+    for (const name of names) {
+      if (!(name in unknownNames)) {
+        unknownNames[name] = [];
+      }
+
+      unknownNames[name].push(type);
+    }
+  }
+
+  return unknownNames;
+}
+
+function isDefinedByLet(node, nodePath) {
+  let current = nodePath;
+
+  while (current) {
+    if (
+      current.node.type === 'BlockStatement' &&
+      current.node.path.original === 'let' &&
+      current.node.program.blockParams.includes(node.tag)
+    ) {
+      return true;
+    }
+
+    current = current.parent;
+  }
+
+  return false;
+}
+
+module.exports = function ({ source, path: templatePath }, { parse, visit }) {
+  const absTemplatePath = path.resolve(templatePath);
+  const packageRoot = getPackageRoot(absTemplatePath);
+  const pathFromRoot = path.relative(packageRoot, absTemplatePath);
+  const namesMapPath = path.join(packageRoot, nameMapFile);
+  const namesMap = readJsonFile(namesMapPath);
+
+  if (!(pathFromRoot in namesMap)) {
+    console.error(
+      `Skipping '${templatePath}' because it could not be found in its package's names map` +
+        ` ('${namesMapPath}'). Make sure stages 2 and 3 completed successfully.`
+    );
+
+    return;
+  }
+
+  const unknownNames = getUnknownNames(namesMap[pathFromRoot]);
+  const ast = parse(source);
+
+  return visit(ast, (env) => {
+    let { builders: b } = env.syntax;
+
+    return {
+      ElementModifierStatement(node) {
+        if (!(node.path.original in unknownNames)) {
+          return;
+        }
+
+        if (!unknownNames[node.path.original].includes('modifiers')) {
+          console.error(
+            `In '${templatePath}', '${node.path.original}' is being used as a modifier, but it is` +
+              ` not listed as one in the package's names map ('${namesMapPath}'). Make sure` +
+              ` stages 2 and 3 completed successfully.`
+          );
+
+          return;
+        }
+
+        node.path = buildResolver(b, node.path.original, 'modifier');
+      },
+
+      ElementNode(node, nodePath) {
+        if (!(node.tag in unknownNames)) {
+          return;
+        }
+
+        if (!unknownNames[node.tag].includes('angleComponents')) {
+          console.error(
+            `In '${templatePath}', '${node.tag}' is being used as a component, but it is` +
+              ` not listed as one in the package's names map ('${namesMapPath}'). Make sure` +
+              ` stages 2 and 3 completed successfully.`
+          );
+
+          return;
+        }
+
+        if (isDefinedByLet(node, nodePath)) {
+          return;
+        }
+
+        return b.block(
+          'let',
+          [b.sexpr('component', [b.string(`${toKebabCase(node.tag)}`)])],
+          undefined,
+          b.blockItself([node], [node.tag])
+        );
+      },
+
+      MustacheStatement(node) {
+        if (!(node.path.original in unknownNames)) {
+          return;
+        }
+
+        if (!unknownNames[node.path.original].includes('ambiguousCurlies')) {
+          console.error(
+            `In '${templatePath}', '${node.path.original}' is being used as ambiguous helper or` +
+              " component, but it is not listed as one in the package's names map" +
+              ` ('${namesMapPath}'). Make sure stages 2 and 3 completed successfully.`
+          );
+
+          return;
+        }
+
+        const nameAsHelper = node.path.original + 'Helper';
+        const nameAsComponent = node.path.original + 'Component';
+        const hasParams = node.params?.length || node.hash?.pairs?.length;
+
+        const nodeAsHelper = hasParams
+          ? b.sexpr(nameAsHelper, node.params, node.hash)
+          : b.path(nameAsHelper);
+
+        const nodeAsComponent = hasParams
+          ? b.sexpr(nameAsComponent, [b.path(nameAsComponent), ...node.params], node.hash)
+          : b.path(nameAsComponent);
+
+        return b.block(
+          'let',
+          [
+            buildResolver(b, node.path.original, 'helper'),
+            buildResolver(b, node.path.original, 'component'),
+          ],
+          undefined,
+          b.blockItself(
+            [b.mustache('if', [b.path(nameAsHelper), nodeAsHelper, nodeAsComponent])],
+            [nameAsHelper, nameAsComponent]
+          )
+        );
+      },
+
+      SubExpression(node) {
+        if (!(node.path.original in unknownNames)) {
+          return;
+        }
+
+        if (!unknownNames[node.path.original].includes('helpers')) {
+          console.error(
+            `In '${templatePath}', '${node.path.original}' is being used as a helper, but it is` +
+              ` not listed as one in the package's names map ('${namesMapPath}'). Make sure` +
+              ` stages 2 and 3 completed successfully.`
+          );
+
+          return;
+        }
+
+        node.path = buildResolver(b, node.path.original, 'helper');
+      },
+    };
+  });
+};
+
+module.exports.type = 'hbs';

--- a/transforms/stage-4-new-years/test.js
+++ b/transforms/stage-4-new-years/test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  name: 'stage-4-new-years',
+});


### PR DESCRIPTION
## Summary

This transform reads the "names map" file created by stages 2 and 3 and uses it to determine which names in the template need replaced with runtime resolvers. The details of which bits of syntax are transformed (and what to) are in stage 4's `README.md`.

## Testing

The new transform relies entirely on the testing tools provided by codemod-cli, so `basic.input.hbs` and `basic.output.hbs` serve as test snapshots.